### PR TITLE
Expand plugin search in nix store

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ TODO: figure out how to play nicely with Mason included in the configuration and
 
 Lazy-Nix-Helper can't currently find plugins installed by Nix on non-NixOS platforms.
 
+Currently only plugins in the `vimplugin` or `lua5.1` package groups are found. That includes all the plugins that I use, but I think there are other package groups where neovim plugins can exist.
+
 ## Troubleshooting
 
 ### How do I check which path a plugin is loaded from?

--- a/TODO.md
+++ b/TODO.md
@@ -5,6 +5,7 @@
 - [x] naive implementation of nix store plugin discovery
 - [ ] make plugin discovery work in a non-nixos environment with nix installed
 - [ ] more robust implementation of nix store plugin discovery
+- [ ] find plugins from all possible package groups, not just `vimplugin` and `lua5.1`
 - [x] get nix store plugin path given a plugin name
 - [ ] can plugin names be made friendlier in configuration without risking collisions?
         can we let the user supply "my-plugin" while also checking the store for
@@ -23,3 +24,7 @@
 ## Installation
 
 - [ ] package plugin and get it merged to nixpkgs
+
+## Meta
+
+- [ ] write some tests

--- a/doc/lazy-nix-helper.nvim.txt
+++ b/doc/lazy-nix-helper.nvim.txt
@@ -235,6 +235,10 @@ KNOWN LIMITATIONS     *lazy-nix-helper.nvim-lazy-nix-helper-known-limitations*
 Lazy-Nix-Helper can’t currently find plugins installed by Nix on non-NixOS
 platforms.
 
+Currently only plugins in the `vimplugin` or `lua5.1` package groups are found.
+That includes all the plugins that I use, but I think there are other package
+groups where neovim plugins can exist.
+
 
 TROUBLESHOOTING         *lazy-nix-helper.nvim-lazy-nix-helper-troubleshooting*
 

--- a/lua/lazy-nix-helper/core.lua
+++ b/lua/lazy-nix-helper/core.lua
@@ -1,0 +1,102 @@
+local Config = require("lazy-nix-helper.config")
+local Util = require("lazy-nix-helper.util")
+
+local M = {}
+
+local plugin_discovery_done = false
+local plugins = {}
+
+-- TODO: should this be checking nix-store is installed instead?
+local function nix_is_installed()
+  return vim.fn.executable("nix")
+end
+
+local function parse_plugin_name_from_nix_store_path(path, capture_group)
+  -- path looks like:
+  -- /nix/store/<hash>-vimplugin-<name>[-<date>]
+  -- use string.match to capture everything after "vimplugin-"
+  local plugin_name_with_possible_date = string.match(path, capture_group)
+  -- date is formatted -YYYY-DD-YY. capture on digits fitting that format at the end of the string
+  local plugin_name = string.match(plugin_name_with_possible_date, "(.-)%-%d%d%d%d%-%d%d%-%d%d$")
+  if plugin_name == nil then
+    plugin_name = plugin_name_with_possible_date
+  end
+  return plugin_name
+end
+
+local function search_nix_store_for_paths_containing_string(query_string)
+  -- NOTE: this will only work for nixos, not packages installed via nix on non-nixos systems
+  local nix_command = "nix-store --query --requisites /run/current-system | grep " .. query_string .. " | sort"
+  local nix_search_handle = io.popen(nix_command)
+  if nix_search_handle == nil then
+    Util.error("Unable to get nix-store search results")
+  else
+    local nix_search_results = nix_search_handle:lines()
+    -- TODO: this is needed, we don't want to leave dangling file handles for lua's GC to clean up
+    -- however, when this is included, attempting to use nix_search_results below gives an error:
+    -- "attempt to use a closed file"
+    -- I'm not sure why that is.
+    -- nix_search_handle:close()
+  return nix_search_results
+  end
+end
+
+local function populate_plugin_table_vimplugins()
+  local nix_search_results = search_nix_store_for_paths_containing_string("vimplugin")
+  local capture_group = ".vimplugin%-(.*)"
+  for line in nix_search_results do
+    local plugin_path = line
+    local plugin_name = parse_plugin_name_from_nix_store_path(line, capture_group)
+    if Util.table_contains(plugins, plugin_name) then
+      Util.error("Plugin name collision detected for plugin name " .. plugin_name)
+    end
+    plugins[plugin_name] = plugin_path
+  end
+end
+
+local function populate_plugin_table_lua5_1()
+  local nix_search_results = search_nix_store_for_paths_containing_string("lua5.1")
+  local capture_group = ".lua5%.1%-(.*)"
+  for line in nix_search_results do
+    local plugin_path = line
+    local plugin_name = parse_plugin_name_from_nix_store_path(line, capture_group)
+    if Util.table_contains(plugins, plugin_name) then
+      Util.error("Plugin name collision detected for plugin name " .. plugin_name)
+    end
+    plugins[plugin_name] = plugin_path
+  end
+end
+
+local function populate_plugin_table()
+  if nix_is_installed then
+    populate_plugin_table_vimplugins()
+    populate_plugin_table_lua5_1()
+  end
+end
+
+function M.get_plugin_path(plugin_name)
+  if not plugin_discovery_done then
+    populate_plugin_table()
+    plugin_discovery_done = true
+  end
+
+  if not plugin_name then
+    Util.error("plugin_name not provided")
+  end
+  -- TODO: is this check necessary?
+  if not Util.table_contains(plugins, plugin_name) then
+    return nil
+  end
+  return plugins[plugin_name]
+end
+
+function M.lazypath()
+  return M.get_plugin_path("lazy.nvim") or Config.options.lazypath
+end
+
+function M.list_discovered_plugins()
+  vim.print(plugins)
+end
+
+
+return M

--- a/lua/lazy-nix-helper/core.lua
+++ b/lua/lazy-nix-helper/core.lua
@@ -98,5 +98,4 @@ function M.list_discovered_plugins()
   vim.print(plugins)
 end
 
-
 return M

--- a/lua/lazy-nix-helper/init.lua
+++ b/lua/lazy-nix-helper/init.lua
@@ -1,106 +1,22 @@
-local Util = require("lazy-nix-helper.util")
 local Config = require("lazy-nix-helper.config")
+local Core = require("lazy-nix-helper.core")
 
 local M = {}
 
-local plugin_discovery_done = false
-local plugins = {}
-
 function M.setup(options)
-  require("lazy-nix-helper.config").setup(options)
-end
-
--- TODO: should this be checking nix-store is installed instead?
-local function nix_is_installed()
-  return vim.fn.executable("nix")
-end
-
-local function parse_plugin_name_from_nix_store_path(path, capture_group)
-  -- path looks like:
-  -- /nix/store/<hash>-vimplugin-<name>[-<date>]
-  -- use string.match to capture everything after "vimplugin-"
-  local plugin_name_with_possible_date = string.match(path, capture_group)
-  -- date is formatted -YYYY-DD-YY. capture on digits fitting that format at the end of the string
-  local plugin_name = string.match(plugin_name_with_possible_date, "(.-)%-%d%d%d%d%-%d%d%-%d%d$")
-  if plugin_name == nil then
-    plugin_name = plugin_name_with_possible_date
-  end
-  return plugin_name
-end
-
-local function search_nix_store_for_paths_containing_string(query_string)
-  -- NOTE: this will only work for nixos, not packages installed via nix on non-nixos systems
-  local nix_command = "nix-store --query --requisites /run/current-system | grep " .. query_string .. " | sort"
-  local nix_search_handle = io.popen(nix_command)
-  if nix_search_handle == nil then
-    Util.error("Unable to get nix-store search results")
-  else
-    local nix_search_results = nix_search_handle:lines()
-    -- TODO: this is needed, we don't want to leave dangling file handles for lua's GC to clean up
-    -- however, when this is included, attempting to use nix_search_results below gives an error:
-    -- "attempt to use a closed file"
-    -- I'm not sure why that is.
-    -- nix_search_handle:close()
-  return nix_search_results
-  end
-end
-
-local function populate_plugin_table_vimplugins()
-  local nix_search_results = search_nix_store_for_paths_containing_string("vimplugin")
-  local capture_group = ".vimplugin%-(.*)"
-  for line in nix_search_results do
-    local plugin_path = line
-    local plugin_name = parse_plugin_name_from_nix_store_path(line, capture_group)
-    if Util.table_contains(plugins, plugin_name) then
-      Util.error("Plugin name collision detected for plugin name " .. plugin_name)
-    end
-    plugins[plugin_name] = plugin_path
-  end
-end
-
-local function populate_plugin_table_lua5_1()
-  local nix_search_results = search_nix_store_for_paths_containing_string("lua5.1")
-  local capture_group = ".lua5%.1%-(.*)"
-  for line in nix_search_results do
-    local plugin_path = line
-    local plugin_name = parse_plugin_name_from_nix_store_path(line, capture_group)
-    if Util.table_contains(plugins, plugin_name) then
-      Util.error("Plugin name collision detected for plugin name " .. plugin_name)
-    end
-    plugins[plugin_name] = plugin_path
-  end
-end
-
-local function populate_plugin_table()
-  if nix_is_installed then
-    populate_plugin_table_vimplugins()
-    populate_plugin_table_lua5_1()
-  end
+  Config.setup(options)
 end
 
 function M.get_plugin_path(plugin_name)
-  if not plugin_discovery_done then
-    populate_plugin_table()
-    plugin_discovery_done = true
-  end
-
-  if not plugin_name then
-    Util.error("plugin_name not provided")
-  end
-  -- TODO: is this check necessary?
-  if not Util.table_contains(plugins, plugin_name) then
-    return nil
-  end
-  return plugins[plugin_name]
-end
-
-function M.list_discovered_plugins()
-  vim.print(plugins)
+  Core.get_plugin_path(plugin_name)
 end
 
 function M.lazypath()
-  return M.get_plugin_path("lazy.nvim") or Config.options.lazypath
+  Core.lazypath()
 end
 
+function M.list_discovered_plugins()
+  Core.list_discovered_plugins()
+end
 
 return M

--- a/lua/lazy-nix-helper/init.lua
+++ b/lua/lazy-nix-helper/init.lua
@@ -8,11 +8,11 @@ function M.setup(options)
 end
 
 function M.get_plugin_path(plugin_name)
-  Core.get_plugin_path(plugin_name)
+  return Core.get_plugin_path(plugin_name)
 end
 
 function M.lazypath()
-  Core.lazypath()
+  return Core.lazypath()
 end
 
 function M.list_discovered_plugins()

--- a/lua/lazy-nix-helper/init.lua
+++ b/lua/lazy-nix-helper/init.lua
@@ -10,10 +10,6 @@ function M.setup(options)
   require("lazy-nix-helper.config").setup(options)
 end
 
-local function table_contains(table, key)
-  return table[key] ~= nil
-end
-
 -- TODO: should this be checking nix-store is installed instead?
 local function nix_is_installed()
   return vim.fn.executable("nix")
@@ -55,7 +51,7 @@ local function populate_plugin_table_vimplugins()
   for line in nix_search_results do
     local plugin_path = line
     local plugin_name = parse_plugin_name_from_nix_store_path(line, capture_group)
-    if table_contains(plugins, plugin_name) then
+    if Util.table_contains(plugins, plugin_name) then
       Util.error("Plugin name collision detected for plugin name " .. plugin_name)
     end
     plugins[plugin_name] = plugin_path
@@ -68,7 +64,7 @@ local function populate_plugin_table_lua5_1()
   for line in nix_search_results do
     local plugin_path = line
     local plugin_name = parse_plugin_name_from_nix_store_path(line, capture_group)
-    if table_contains(plugins, plugin_name) then
+    if Util.table_contains(plugins, plugin_name) then
       Util.error("Plugin name collision detected for plugin name " .. plugin_name)
     end
     plugins[plugin_name] = plugin_path
@@ -92,7 +88,7 @@ function M.get_plugin_path(plugin_name)
     Util.error("plugin_name not provided")
   end
   -- TODO: is this check necessary?
-  if not table_contains(plugins, plugin_name) then
+  if not Util.table_contains(plugins, plugin_name) then
     return nil
   end
   return plugins[plugin_name]

--- a/lua/lazy-nix-helper/init.lua
+++ b/lua/lazy-nix-helper/init.lua
@@ -10,16 +10,20 @@ function M.setup(options)
   require("lazy-nix-helper.config").setup(options)
 end
 
+local function table_contains(table, key)
+  return table[key] ~= nil
+end
+
 -- TODO: should this be checking nix-store is installed instead?
 local function nix_is_installed()
   return vim.fn.executable("nix")
 end
 
-local function parse_plugin_name_from_nix_store_path(path)
+local function parse_plugin_name_from_nix_store_path(path, capture_group)
   -- path looks like:
   -- /nix/store/<hash>-vimplugin-<name>[-<date>]
   -- use string.match to capture everything after "vimplugin-"
-  local plugin_name_with_possible_date = string.match(path, ".vimplugin%-(.*)")
+  local plugin_name_with_possible_date = string.match(path, capture_group)
   -- date is formatted -YYYY-DD-YY. capture on digits fitting that format at the end of the string
   local plugin_name = string.match(plugin_name_with_possible_date, "(.-)%-%d%d%d%d%-%d%d%-%d%d$")
   if plugin_name == nil then
@@ -28,36 +32,59 @@ local function parse_plugin_name_from_nix_store_path(path)
   return plugin_name
 end
 
-function M.populate_plugin_table()
-  if nix_is_installed then
-    -- NOTE: this will only work for nixos, not packages installed via nix on non-nixos systems
-    local nix_command = "nix-store --query --requisites /run/current-system | grep vimplugin | sort"
-    local nix_search_handle = io.popen(nix_command)
-    if nix_search_handle == nil then
-      Util.error("Unable to get nix-store search results")
-    else
-      local nix_search_results = nix_search_handle:lines()
-      -- TODO: this is needed, we don't want to leave dangling file handles for lua's GC to clean up
-      -- however, when this is included, attempting to use nix_search_results below gives an error:
-      -- "attempt to use a closed file"
-      -- I'm not sure why that is.
-      -- nix_search_handle:close()
-      for line in nix_search_results do
-        local plugin_path = line
-        local plugin_name = parse_plugin_name_from_nix_store_path(line)
-        plugins[plugin_name] = plugin_path
-      end
-    end
+local function search_nix_store_for_paths_containing_string(query_string)
+  -- NOTE: this will only work for nixos, not packages installed via nix on non-nixos systems
+  local nix_command = "nix-store --query --requisites /run/current-system | grep " .. query_string .. " | sort"
+  local nix_search_handle = io.popen(nix_command)
+  if nix_search_handle == nil then
+    Util.error("Unable to get nix-store search results")
+  else
+    local nix_search_results = nix_search_handle:lines()
+    -- TODO: this is needed, we don't want to leave dangling file handles for lua's GC to clean up
+    -- however, when this is included, attempting to use nix_search_results below gives an error:
+    -- "attempt to use a closed file"
+    -- I'm not sure why that is.
+    -- nix_search_handle:close()
+  return nix_search_results
   end
 end
 
-local function table_contains(table, key)
-  return table[key] ~= nil
+local function populate_plugin_table_vimplugins()
+  local nix_search_results = search_nix_store_for_paths_containing_string("vimplugin")
+  local capture_group = ".vimplugin%-(.*)"
+  for line in nix_search_results do
+    local plugin_path = line
+    local plugin_name = parse_plugin_name_from_nix_store_path(line, capture_group)
+    if table_contains(plugins, plugin_name) then
+      Util.error("Plugin name collision detected for plugin name " .. plugin_name)
+    end
+    plugins[plugin_name] = plugin_path
+  end
+end
+
+local function populate_plugin_table_lua5_1()
+  local nix_search_results = search_nix_store_for_paths_containing_string("lua5.1")
+  local capture_group = ".lua5%.1%-(.*)"
+  for line in nix_search_results do
+    local plugin_path = line
+    local plugin_name = parse_plugin_name_from_nix_store_path(line, capture_group)
+    if table_contains(plugins, plugin_name) then
+      Util.error("Plugin name collision detected for plugin name " .. plugin_name)
+    end
+    plugins[plugin_name] = plugin_path
+  end
+end
+
+local function populate_plugin_table()
+  if nix_is_installed then
+    populate_plugin_table_vimplugins()
+    populate_plugin_table_lua5_1()
+  end
 end
 
 function M.get_plugin_path(plugin_name)
   if not plugin_discovery_done then
-    M.populate_plugin_table()
+    populate_plugin_table()
     plugin_discovery_done = true
   end
 

--- a/lua/lazy-nix-helper/util.lua
+++ b/lua/lazy-nix-helper/util.lua
@@ -4,4 +4,8 @@ function M.error(msg)
   vim.notify(msg, vim.log.levels.ERROR, { title = "lazy-nix-helper" })
 end
 
+function M.table_contains(table, key)
+  return table[key] ~= nil
+end
+
 return M


### PR DESCRIPTION
initial plugin search only included packages in the `vimplugin` group, which did not include things like telescope and plenary. expand plugin search to also include packages from `lua5.1`

there are assuredly plugins in other package groups that are still missing, but this includes all the plugins that I currently use

while I'm in there, refactor plugin discovery functions. also reorganize code so that `init.lua` only defines the public interface of the plugin 